### PR TITLE
Fixed a crash

### DIFF
--- a/WPObjectMapper/NSObject+ObjectMap.m
+++ b/WPObjectMapper/NSObject+ObjectMap.m
@@ -563,7 +563,8 @@ const char * property_getTypeString( objc_property_t property )
             }
             
             // Finally add that object
-            [objectsArray addObject:nestedObj];
+            if (nestedObj)
+                [objectsArray addObject:nestedObj];
         }
 
         // Should never reach here due to the continue statement near the top of the for loop. Leaving for historical purposes in case we need to re-implement.


### PR DESCRIPTION
Looks like there's a consistent crash in this code where the `nestedObject` becomes `nil` and then NSArray complains that we are trying to add a `nil` object.

Not sure exactly why it is becoming `nil` - my Objective-C reading skills 👓 aren't what they used to be.