### PR TITLE
MON-242: Library Support for Monet

### DIFF
--- a/WPObjectMapper.podspec
+++ b/WPObjectMapper.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.author       = "The Washington Post"
 
   s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
   s.source       = { :git => "git@github.com:WPMedia/ios-object-mapper.git", :tag => s.version.to_s }


### PR DESCRIPTION
# MON-242: Library Support for Monet
[Jira](https://arcpublishing.atlassian.net/browse/MON-242)

### Background
* Adds tvOS deployment_target attribute to WPObjectMapper's Podspec to enable us to support tvOS development for project Monet

```
➜  ios-object-mapper git:(story/mon-242/monet-library-support) pod lib lint WPObjectMapper.podspec --private --allow-warnings --verbose --no-clean --sources=wpmedia,master
...
WPObjectMapper passed validation.
➜  ios-object-mapper git:(story/mon-242/monet-library-support) 
```

### Related PR
- [PostKit](https://github.com/wpmedia/ios-postkit/pulls/TODO)